### PR TITLE
Use new HE installer.

### DIFF
--- a/roles/hosted-engine/tasks/install.yml
+++ b/roles/hosted-engine/tasks/install.yml
@@ -30,6 +30,6 @@
     need_hosted_engine_deploy: "{{ check_hosted_engine.stdout == 'You must run deploy first' }}"
 
 - name: install the hosted engine if it is not present
-  shell: hosted-engine --deploy --config-append=/tmp/he-answers.conf < /dev/null
+  shell: hosted-engine --ansible --deploy --config-append=/tmp/he-answers.conf < /dev/null
   register: hosted_engine_install
   when: need_hosted_engine_deploy


### PR DESCRIPTION
This change introduces usage of the `--ansible` option on the `hosted-engine` installer, which causes it to use the new Ansible based installer. This will remove the need to configure storage domains and speeds up the process in general.